### PR TITLE
Add a simpler SoundCloud search command

### DIFF
--- a/constants.toml
+++ b/constants.toml
@@ -21,6 +21,7 @@
   search     = "Searches for a song on youtube"
   shuffle    = "Shuffles the song queue"
   skip       = "Plays the next song in the queue"
+  soundcloud = "Searches for a song from soundcloud"
   stop       = "Stops playing and leaves the voice channel"
   volume     = "Changes the music volume"
 

--- a/src/main/java/ovh/not/javamusicbot/CommandManager.java
+++ b/src/main/java/ovh/not/javamusicbot/CommandManager.java
@@ -42,6 +42,7 @@ public class CommandManager {
                 new SearchCommand(this),
                 new ShuffleCommand(),
                 new SkipCommand(),
+                new SoundcloudCommand(this, playerManager),
                 new StopCommand(),
                 new VolumeCommand(config)
         );

--- a/src/main/java/ovh/not/javamusicbot/command/BasePlayCommand.java
+++ b/src/main/java/ovh/not/javamusicbot/command/BasePlayCommand.java
@@ -1,0 +1,63 @@
+package ovh.not.javamusicbot.command;
+
+import com.sedmelluq.discord.lavaplayer.player.AudioPlayerManager;
+import net.dv8tion.jda.core.Permission;
+import net.dv8tion.jda.core.entities.VoiceChannel;
+import ovh.not.javamusicbot.Command;
+import ovh.not.javamusicbot.CommandManager;
+import ovh.not.javamusicbot.GuildMusicManager;
+import ovh.not.javamusicbot.LoadResultHandler;
+
+import java.util.Set;
+
+public abstract class BasePlayCommand extends Command {
+    private final CommandManager commandManager;
+    private final AudioPlayerManager playerManager;
+
+    BasePlayCommand(CommandManager commandManager, AudioPlayerManager playerManager, String name, String... names) {
+        super(name, names);
+        this.commandManager = commandManager;
+        this.playerManager = playerManager;
+    }
+
+    @Override
+    public void on(Context context) {
+        if (context.args.length == 0) {
+            context.reply(this.noArgumentMessage());
+            return;
+        }
+        VoiceChannel channel = context.event.getMember().getVoiceState().getChannel();
+        if (channel == null) {
+            context.reply("You must be in a voice channel!");
+            return;
+        }
+        GuildMusicManager musicManager = GuildMusicManager.getOrCreate(context.event.getGuild(),
+                context.event.getTextChannel(), playerManager);
+        if (musicManager.open && musicManager.player.getPlayingTrack() != null
+                && musicManager.channel != channel
+                && !context.event.getMember().hasPermission(musicManager.channel, Permission.VOICE_MOVE_OTHERS)) {
+            context.reply("dabBot is already playing music in " + musicManager.channel.getName() + " so it cannot " +
+                    "be moved. Members with the `VOICE_MOVE_OTHERS` permission are exempt from this.");
+            return;
+        }
+        LoadResultHandler handler = new LoadResultHandler(commandManager, musicManager, playerManager, context);
+        handler.allowSearch = true;
+        Set<String> flags = context.parseFlags();
+        if (flags.contains("first") || flags.contains("f")) {
+            handler.setFirstInQueue = true;
+        }
+
+        context.args = this.transformQuery(context.args);
+
+        playerManager.loadItem(String.join(" ", context.args), handler);
+        if (!musicManager.open) {
+            musicManager.open(channel, context.event.getAuthor());
+        }
+    }
+
+    abstract String noArgumentMessage();
+
+    private String[] transformQuery(String[] args) {
+        return args;
+    }
+}

--- a/src/main/java/ovh/not/javamusicbot/command/PlayCommand.java
+++ b/src/main/java/ovh/not/javamusicbot/command/PlayCommand.java
@@ -1,56 +1,16 @@
 package ovh.not.javamusicbot.command;
 
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayerManager;
-import net.dv8tion.jda.core.Permission;
-import net.dv8tion.jda.core.entities.VoiceChannel;
-import ovh.not.javamusicbot.Command;
 import ovh.not.javamusicbot.CommandManager;
-import ovh.not.javamusicbot.GuildMusicManager;
-import ovh.not.javamusicbot.LoadResultHandler;
 
-import java.util.Set;
-
-public class PlayCommand extends Command {
-    private final CommandManager commandManager;
-    private final AudioPlayerManager playerManager;
-
+public class PlayCommand extends BasePlayCommand {
     public PlayCommand(CommandManager commandManager, AudioPlayerManager playerManager) {
-        super("play", "p");
-        this.commandManager = commandManager;
-        this.playerManager = playerManager;
+        super(commandManager, playerManager, "play", "p");
     }
 
-    @Override
-    public void on(Context context) {
-        if (context.args.length == 0) {
-            context.reply("Usage: `%prefix%play <link>` - plays a song\n" +
-                    "To search youtube, use `%prefix%play <youtube video title>`\n" +
-                    "To add as first in queue, use `%prefix%play <link> -first`");
-            return;
-        }
-        VoiceChannel channel = context.event.getMember().getVoiceState().getChannel();
-        if (channel == null) {
-            context.reply("You must be in a voice channel!");
-            return;
-        }
-        GuildMusicManager musicManager = GuildMusicManager.getOrCreate(context.event.getGuild(),
-                context.event.getTextChannel(), playerManager);
-        if (musicManager.open && musicManager.player.getPlayingTrack() != null
-                && musicManager.channel != channel
-                && !context.event.getMember().hasPermission(musicManager.channel, Permission.VOICE_MOVE_OTHERS)) {
-            context.reply("dabBot is already playing music in " + musicManager.channel.getName() + " so it cannot " +
-                    "be moved. Members with the `VOICE_MOVE_OTHERS` permission are exempt from this.");
-            return;
-        }
-        LoadResultHandler handler = new LoadResultHandler(commandManager, musicManager, playerManager, context);
-        handler.allowSearch = true;
-        Set<String> flags = context.parseFlags();
-        if (flags.contains("first") || flags.contains("f")) {
-            handler.setFirstInQueue = true;
-        }
-        playerManager.loadItem(String.join(" ", context.args), handler);
-        if (!musicManager.open) {
-            musicManager.open(channel, context.event.getAuthor());
-        }
+    String noArgumentMessage() {
+        return "Usage: `%prefix%play <link>` - plays a song\n" +
+                "To search youtube, use `%prefix%play <youtube video title>`\n" +
+                "To add as first in queue, use `%prefix%play <link> -first`";
     }
 }

--- a/src/main/java/ovh/not/javamusicbot/command/SoundcloudCommand.java
+++ b/src/main/java/ovh/not/javamusicbot/command/SoundcloudCommand.java
@@ -1,0 +1,20 @@
+package ovh.not.javamusicbot.command;
+
+import com.sedmelluq.discord.lavaplayer.player.AudioPlayerManager;
+import ovh.not.javamusicbot.CommandManager;
+
+public class SoundcloudCommand extends BasePlayCommand {
+    public SoundcloudCommand(CommandManager commandManager, AudioPlayerManager playerManager) {
+        super(commandManager, playerManager, "soundcloud", "sc");
+    }
+
+    String noArgumentMessage() {
+        return "Usage: `%prefix%soundcloud <song title>` - searches for a song from soundcloud\n\n" +
+                "If you already have a link to a song, use `%prefix%play <link>`";
+    }
+
+    String[] transformQuery(String[] args) {
+        args[0] = "scsearch:" + args[0];
+        return args;
+    }
+}


### PR DESCRIPTION
The current method of searching via soundcloud is by prefixing the
search query for the play command with "scsearch:". In total, this is
used like `!!!play scsearch:rameses b mountains`. This is non-ergonomic
for the user.

Instead, create a second command specifically for this platform, used
like `!!!soundcloud rameses b mountains`, with `!!!sc` as a shortcut.

To make this more feasible without code duplication, the core logic has
been moved out to an abstract `BasePlayCommand`, leaving query
transformation logic (prefixing `scsearch` to the query) to be
overridden, and a method to be implemented with the purpose of
customizing the message sent when no arguments are provided.

tl;dr:

Old command usage:
`!!!play scsearch:rameses b mountains`

New command usage:
`!!!soundcloud rameses b mountains` or `!!!sc rameses b mountains`